### PR TITLE
Delegate to `str` for trait implementations

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -203,7 +203,7 @@ impl<T> fmt::Debug for StringWrapper<T> where T: Buffer {
 
 impl<T: Buffer> PartialEq for StringWrapper<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.buffer.as_ref()[..self.len] == other.buffer.as_ref()[..self.len]
+        **self == **other
     }
 }
 
@@ -215,14 +215,13 @@ impl<T: Buffer> PartialOrd for StringWrapper<T> {
 
 impl<T: Buffer> hash::Hash for StringWrapper<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.len.hash(state);
-        self.buffer.as_ref()[..self.len].hash(state);
+        (**self).hash(state)
     }
 }
 
 impl<T: Buffer + Eq> Ord for StringWrapper<T> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.buffer.as_ref()[..self.len].cmp(&other.buffer.as_ref()[..self.len])
+        (**self).cmp(&**other)
     }
 }
 

--- a/lib.rs
+++ b/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow;
 use std::fmt;
 use std::io::Write;
 use std::mem::transmute;
@@ -187,6 +188,10 @@ impl<T> ops::DerefMut for StringWrapper<T> where T: Buffer {
             transmute::<&mut [u8], &mut str>(&mut self.buffer.as_mut()[..self.len])
         }
     }
+}
+
+impl<T> borrow::Borrow<str> for StringWrapper<T> where T: Buffer {
+    fn borrow(&self) -> &str { self }
 }
 
 impl<T> fmt::Display for StringWrapper<T> where T: Buffer {


### PR DESCRIPTION
Mostly this is just for readability, but in the case of Hash it also allows StringWrapper to implement `Borrow<str>`, so `&str` can be used to query a `HashMap<StringWrapper, T>`.